### PR TITLE
Adjust kb filter to use slash instead of hash

### DIFF
--- a/tests/CASE-Examples/examples/Makefile
+++ b/tests/CASE-Examples/examples/Makefile
@@ -146,7 +146,7 @@ local_ontology_vocabulary-%.txt: \
 	    > $@___
 	grep ':' $@___ \
 	  | egrep -v '(acme.org|purl.org|w3.org)' \
-	    | grep -v '/kb#' \
+	    | grep -v '/kb/' \
 	      > $@__
 	rm $@___
 	LC_ALL=C \


### PR DESCRIPTION
References:
* [AC-134] Document IRI usage of hash vs. slash

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>