### PR TITLE
Use alternative EDM Council download location

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -20,16 +20,25 @@ all: \
 # at:
 #   https://github.com/edmcouncil/rdf-toolkit
 # However, on the file becoming temporarily unavailable, CASE has placed
-# a verified copy at a custom location.
-# The checksum of the original file from EDM Council is confirmed before
-# moving file into position.  (This practice will probably require
-# frequent updates, unless a signed checksum for the jar can be
-# retrieved somehow.)
+# a verified copy at a custom location, as a fallback for an alternative
+# retrieval from an EDM Council member's repository.
+# The checksum of the original file from EDM Council's build server is
+# confirmed before moving file into position.  (This practice will
+# probably require frequent updates, unless a signed checksum for the
+# jar can be retrieved somehow.)
+# In case there are concerns on potentially multiple writes to the same
+# file, the documentation for wget's "--output-document file" flag notes
+# that "... file will be truncated immediately, and all downloaded
+# content will be written there."
 rdf-toolkit.jar: \
   rdf-toolkit.jar.sha512
+	# Try retrieval from Github, then from files.caseontology.org.
 	wget \
 	  --output-document $@_ \
-	  http://files.caseontology.org/rdf-toolkit.jar
+	  https://github.com/trypuz/openfibo/blob/1f9ab415e8ebd131eadcc9b0fc46241adeeb0384/etc/serialization/rdf-toolkit.jar?raw=true \
+	  || wget \
+	    --output-document $@_ \
+	    http://files.caseontology.org/rdf-toolkit.jar
 	test \
 	  "x$$(openssl dgst -sha512 $@_ | awk '{print($$NF)}')" \
 	  == \


### PR DESCRIPTION
One of the maintainers on the rdf-toolkit Github repository had
committed the built jar we were using into another repository.
I confirmed that the SHA-512 of this file matches what was recorded in
the CASE repository.  This patch implements a fallback download pattern,
favoring downloading from Github, and then from files.caseontology.org.

References:
* [ONT-383] Find alternative retrieval point for rdf-toolkit.jar

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>