### PR TITLE
Report on current usage of kindOfRelationship

### DIFF
--- a/src/data_relationship_literals_tsv.py
+++ b/src/data_relationship_literals_tsv.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+"""
+This script is for reporting the kindOfRelationship vocabulary literals used in instance-data files.
+"""
+
+__version__ = "0.1.0"
+
+import os
+import sys
+import logging
+
+import rdflib.plugins.sparql
+
+_logger = logging.getLogger(os.path.basename(__file__))
+
+NS_XSD_STRING_IRI = rdflib.XSD.string.toPython()
+
+def main():
+    #_logger.info("sys.getrecursionlimit() = %d." % sys.getrecursionlimit())
+
+    # Pairs: datatype, value
+    vocabset = set()
+
+    for arg in args.in_file:
+        _logger.info("arg=%r" % arg)
+        graph = rdflib.Graph()
+        graph.parse(arg, format="json-ld" if arg.endswith("json") else "turtle")
+        _logger.info("len(graph)=%d" % len(graph))
+
+        nsdict = {k:v for (k,v) in graph.namespace_manager.namespaces()}
+
+        query = rdflib.plugins.sparql.prepareQuery("""\
+SELECT ?lKindOfRelationship
+WHERE {
+  ?nRelationship uco-core:kindOfRelationship ?lKindOfRelationship .
+}""", initNs=nsdict)
+        for (result_no, result) in enumerate(graph.query(query)):
+            (l_value,) = result
+            if l_value.datatype is None:
+                datatype = NS_XSD_STRING_IRI
+            else:
+                datatype = l_value.datatype.toPython()
+            value = l_value.toPython()
+            vocabset.add((datatype, value))
+        del graph
+
+    for record in sorted(vocabset):
+        try:
+            print("\t".join(record))
+        except:
+            _logger.error(record)
+            raise
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("in_file", nargs="+")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/src/ontology_relationship_literals_tsv.py
+++ b/src/ontology_relationship_literals_tsv.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+"""
+This script is for reporting the kindOfRelationship vocabulary literals used in instance-data files.
+"""
+
+__version__ = "0.1.0"
+
+import os
+import sys
+import logging
+
+import rdflib.plugins.sparql
+
+_logger = logging.getLogger(os.path.basename(__file__))
+
+NS_UCO_VOCABULARY = rdflib.Namespace("https://unifiedcyberontology.org/ontology/uco/vocabulary#")
+
+def main():
+    #_logger.info("sys.getrecursionlimit() = %d." % sys.getrecursionlimit())
+
+    # Pairs: datatype, value
+    vocabset = set()
+
+    for arg in args.in_file:
+        _logger.info("arg=%r" % arg)
+        graph = rdflib.Graph()
+        graph.parse(arg, format="turtle")
+        _logger.info("len(graph)=%d" % len(graph))
+
+        nsdict = {k:v for (k,v) in graph.namespace_manager.namespaces()}
+
+        # owl:oneOf query syntax via: https://stackoverflow.com/a/37059201
+        query = rdflib.plugins.sparql.prepareQuery("""\
+SELECT ?lKindOfRelationship
+WHERE {
+  ?nDataType
+    a rdfs:Datatype ;
+    owl:oneOf/rdf:rest*/rdf:first ?lKindOfRelationship .
+}""", initNs=nsdict)
+        for n_datatype in [
+          NS_UCO_VOCABULARY.ActionRelationshipTypeVocab,
+          NS_UCO_VOCABULARY.ObservableObjectRelationshipVocab
+        ]:
+            datatype = n_datatype.toPython()
+            for (result_no, result) in enumerate(graph.query(query, initBindings={"nDataType": n_datatype})):
+                (l_value,) = result
+                value = l_value.toPython()
+                vocabset.add((datatype, value))
+        del graph
+    assert len(vocabset) > 0, "Failed to load expected vocabularies."
+
+    for record in sorted(vocabset):
+        try:
+            print("\t".join(record))
+        except:
+            _logger.error(record)
+            raise
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("in_file", nargs="+")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
+ontology_relationship_literals.tsv
 ontology_vocabulary.txt

--- a/tests/CASE-Examples/examples/.README.md.in
+++ b/tests/CASE-Examples/examples/.README.md.in
@@ -7,3 +7,9 @@ The following table is the count of unknown terms yet used in each example file:
 ```
 @WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@
 ```
+
+The following table is the count of unknown relationship literals used in each example file:
+
+```
+@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@
+```

--- a/tests/CASE-Examples/examples/.gitignore
+++ b/tests/CASE-Examples/examples/.gitignore
@@ -1,4 +1,5 @@
 *.json
 *.sed
 *.ttl
+wc_l_local_ontology_relationships.txt
 wc_l_local_ontology_vocabulary.txt

--- a/tests/CASE-Examples/examples/Makefile
+++ b/tests/CASE-Examples/examples/Makefile
@@ -62,6 +62,7 @@ NORMALIZED_TTL := $(foreach filename,$(FILES),$(filename).ttl)
 
 CHECK_TARGETS := $(foreach filename,$(FILES),check-$(filename))
 
+LOCAL_ONTOLOGY_RELATIONSHIPS_TARGETS := $(foreach filename,$(FILES),local_ontology_relationships-$(filename).tsv)
 LOCAL_ONTOLOGY_VOCABULARY_TARGETS := $(foreach filename,$(FILES),local_ontology_vocabulary-$(filename).txt)
 
 all: \
@@ -101,9 +102,16 @@ $(top_srcdir)/.lib.done.log:
 #   https://stackoverflow.com/a/6790967
 README.md: \
   .README.md.in \
+  wc_l_local_ontology_relationships.txt \
   wc_l_local_ontology_vocabulary.txt
 	rm -f _$@ __$@
 	cp .README.md.in __$@
+	sed \
+	  -e '/@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@/r wc_l_local_ontology_relationships.txt' \
+	  -e '/@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@/d' \
+	  __$@ \
+	  > _$@
+	cp _$@ __$@
 	sed \
 	  -e '/@WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@/r wc_l_local_ontology_vocabulary.txt' \
 	  -e '/@WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@/d' \
@@ -133,6 +141,22 @@ clean:
 	  *.txt \
 	  *_
 	@touch .README.md.in
+
+local_ontology_relationships-%.tsv: \
+  %.ttl \
+  $(top_srcdir)/src/data_relationship_literals_tsv.py \
+  $(top_srcdir)/tests/ontology_relationship_literals.tsv
+	source $(top_srcdir)/venv/bin/activate \
+	  && python3 $(top_srcdir)/src/data_relationship_literals_tsv.py \
+	    $< \
+	    > $@__
+	LC_ALL=C $(COMM) \
+	  -13 \
+	  $(top_srcdir)/tests/ontology_relationship_literals.tsv \
+	  <(LC_ALL=C $(SORT) $@__) \
+	  > $@_
+	rm $@__
+	mv $@_ $@
 
 # The grep patterns confirm that:
 # * There is a namespace present (the colon - blank nodes were slipping by otherwise)
@@ -178,6 +202,14 @@ single_namespace_corrections.sed: \
 	rm $@__
 	mv $@_ $@
 
+undefined_relationships.tsv: \
+  $(LOCAL_ONTOLOGY_RELATIONSHIPS_TARGETS)
+	cat $^ \
+	  | LC_ALL=C $(SORT) \
+	    | uniq \
+	      > $@_
+	mv $@_ $@
+
 undefined_vocabulary.txt: \
   $(LOCAL_ONTOLOGY_VOCABULARY_TARGETS)
 	cat $^ \
@@ -185,6 +217,15 @@ undefined_vocabulary.txt: \
 	    | uniq \
 	      > $@_
 	mv $@_ $@
+
+wc_l_local_ontology_relationships.txt: \
+  undefined_relationships.tsv
+	$(WC) -l \
+	  $(LOCAL_ONTOLOGY_RELATIONSHIPS_TARGETS) \
+	  undefined_relationships.tsv \
+	  | grep -v ' total' \
+	    > _$@
+	mv _$@ $@
 
 wc_l_local_ontology_vocabulary.txt: \
   undefined_vocabulary.txt

--- a/tests/CASE-Examples/examples/README.md
+++ b/tests/CASE-Examples/examples/README.md
@@ -23,3 +23,25 @@ The following table is the count of unknown terms yet used in each example file:
    1 local_ontology_vocabulary-sms_and_contacts.txt
   24 undefined_vocabulary.txt
 ```
+
+The following table is the count of unknown relationship literals used in each example file:
+
+```
+   6 local_ontology_relationships-Oresteia.tsv
+   2 local_ontology_relationships-accounts.tsv
+   2 local_ontology_relationships-bulk_extractor_forensic_path.tsv
+   0 local_ontology_relationships-call_log.tsv
+   0 local_ontology_relationships-device.tsv
+   1 local_ontology_relationships-exif_data.tsv
+   5 local_ontology_relationships-file.tsv
+   1 local_ontology_relationships-forensic_lifecycle.tsv
+   0 local_ontology_relationships-location.tsv
+   1 local_ontology_relationships-message.tsv
+   1 local_ontology_relationships-mobile_device_and_sim_card.tsv
+   2 local_ontology_relationships-multipart_file.tsv
+   1 local_ontology_relationships-network_connection.tsv
+   1 local_ontology_relationships-raw_data.tsv
+   2 local_ontology_relationships-reconstructed_file.tsv
+   1 local_ontology_relationships-sms_and_contacts.tsv
+  17 undefined_relationships.tsv
+```

--- a/tests/CASE-Examples/examples/local_ontology_relationships-Oresteia.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-Oresteia.tsv
@@ -1,0 +1,6 @@
+http://www.w3.org/2001/XMLSchema#string	Attachment_Of
+http://www.w3.org/2001/XMLSchema#string	Has_Account
+http://www.w3.org/2001/XMLSchema#string	Has_Device
+http://www.w3.org/2001/XMLSchema#string	Has_Role
+http://www.w3.org/2001/XMLSchema#string	Located_At
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within

--- a/tests/CASE-Examples/examples/local_ontology_relationships-accounts.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-accounts.tsv
@@ -1,0 +1,2 @@
+http://www.w3.org/2001/XMLSchema#string	associated-account
+http://www.w3.org/2001/XMLSchema#string	has-account

--- a/tests/CASE-Examples/examples/local_ontology_relationships-bulk_extractor_forensic_path.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-bulk_extractor_forensic_path.tsv
@@ -1,0 +1,2 @@
+http://www.w3.org/2001/XMLSchema#string	decompressed-from
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within

--- a/tests/CASE-Examples/examples/local_ontology_relationships-exif_data.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-exif_data.tsv
@@ -1,0 +1,1 @@
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within

--- a/tests/CASE-Examples/examples/local_ontology_relationships-file.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-file.tsv
@@ -1,0 +1,5 @@
+http://www.w3.org/2001/XMLSchema#string	decoded-from
+http://www.w3.org/2001/XMLSchema#string	decrypted-from
+http://www.w3.org/2001/XMLSchema#string	forensic_image_of
+http://www.w3.org/2001/XMLSchema#string	stored-on
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within

--- a/tests/CASE-Examples/examples/local_ontology_relationships-forensic_lifecycle.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-forensic_lifecycle.tsv
@@ -1,0 +1,1 @@
+https://unifiedcyberontology.org/ontology/uco/vocabulary#CyberItemRelationshipVocab	Mapped_Into

--- a/tests/CASE-Examples/examples/local_ontology_relationships-message.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-message.tsv
@@ -1,0 +1,1 @@
+http://www.w3.org/2001/XMLSchema#string	attachment-of

--- a/tests/CASE-Examples/examples/local_ontology_relationships-mobile_device_and_sim_card.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-mobile_device_and_sim_card.tsv
@@ -1,0 +1,1 @@
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within

--- a/tests/CASE-Examples/examples/local_ontology_relationships-multipart_file.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-multipart_file.tsv
@@ -1,0 +1,2 @@
+http://www.w3.org/2001/XMLSchema#string	has-fragment
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within

--- a/tests/CASE-Examples/examples/local_ontology_relationships-network_connection.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-network_connection.tsv
@@ -1,0 +1,1 @@
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within

--- a/tests/CASE-Examples/examples/local_ontology_relationships-raw_data.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-raw_data.tsv
@@ -1,0 +1,1 @@
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within

--- a/tests/CASE-Examples/examples/local_ontology_relationships-reconstructed_file.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-reconstructed_file.tsv
@@ -1,0 +1,2 @@
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within
+https://unifiedcyberontology.org/ontology/uco/vocabulary#ObservableObjectRelationshipVocab	Has_Fragment

--- a/tests/CASE-Examples/examples/local_ontology_relationships-sms_and_contacts.tsv
+++ b/tests/CASE-Examples/examples/local_ontology_relationships-sms_and_contacts.tsv
@@ -1,0 +1,1 @@
+http://www.w3.org/2001/XMLSchema#string	has-account

--- a/tests/CASE-Examples/examples/undefined_relationships.tsv
+++ b/tests/CASE-Examples/examples/undefined_relationships.tsv
@@ -1,0 +1,17 @@
+http://www.w3.org/2001/XMLSchema#string	Attachment_Of
+http://www.w3.org/2001/XMLSchema#string	Has_Account
+http://www.w3.org/2001/XMLSchema#string	Has_Device
+http://www.w3.org/2001/XMLSchema#string	Has_Role
+http://www.w3.org/2001/XMLSchema#string	Located_At
+http://www.w3.org/2001/XMLSchema#string	associated-account
+http://www.w3.org/2001/XMLSchema#string	attachment-of
+http://www.w3.org/2001/XMLSchema#string	decoded-from
+http://www.w3.org/2001/XMLSchema#string	decompressed-from
+http://www.w3.org/2001/XMLSchema#string	decrypted-from
+http://www.w3.org/2001/XMLSchema#string	forensic_image_of
+http://www.w3.org/2001/XMLSchema#string	has-account
+http://www.w3.org/2001/XMLSchema#string	has-fragment
+http://www.w3.org/2001/XMLSchema#string	stored-on
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within
+https://unifiedcyberontology.org/ontology/uco/vocabulary#CyberItemRelationshipVocab	Mapped_Into
+https://unifiedcyberontology.org/ontology/uco/vocabulary#ObservableObjectRelationshipVocab	Has_Fragment

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -27,11 +27,13 @@ all: \
   all-casework.github.io
 
 all-CASE-Examples: \
+  ontology_relationship_literals.tsv \
   ontology_vocabulary.txt
 	$(MAKE) \
 	  --directory CASE-Examples
 
 all-casework.github.io: \
+  ontology_relationship_literals.tsv \
   ontology_vocabulary.txt
 	$(MAKE) \
 	  --directory casework.github.io
@@ -82,11 +84,24 @@ normalize: \
 	  --directory CASE-Examples \
 	  normalize
 
+ontology_relationship_literals.tsv: \
+  $(top_srcdir)/src/ontology_relationship_literals_tsv.py
+	source $(top_srcdir)/venv/bin/activate \
+	  && python3 $(top_srcdir)/src/ontology_relationship_literals_tsv.py \
+	    $(top_srcdir)/dependencies/CASE-Examples/dependencies/UCO/uco-vocabulary/vocabulary.ttl \
+	    > $@__
+	LC_ALL=C \
+	  $(SORT) \
+	    $@__ \
+	    > $@_
+	rm $@__
+	mv $@_ $@
+
 #This file is needed to test examples in CASE-Examples and the website.
 ontology_vocabulary.txt: \
   $(top_srcdir)/src/ontology_classes_properties.py
 	source $(top_srcdir)/venv/bin/activate \
-	  && python $(top_srcdir)/src/ontology_classes_properties.py \
+	  && python3 $(top_srcdir)/src/ontology_classes_properties.py \
 	    $(top_srcdir)/dependencies/CASE-Examples/dependencies/CASE/ontology/*/*ttl \
 	    $(top_srcdir)/dependencies/CASE-Examples/dependencies/UCO/*/*ttl \
 	    > $@__

--- a/tests/casework.github.io/examples/.gitignore
+++ b/tests/casework.github.io/examples/.gitignore
@@ -1,2 +1,3 @@
 *.diff
+wc_l_local_ontology_relationships.txt
 wc_l_local_ontology_vocabulary.txt

--- a/tests/casework.github.io/examples/asgard/.README.md.in
+++ b/tests/casework.github.io/examples/asgard/.README.md.in
@@ -7,3 +7,9 @@ The following table is the count of unknown terms yet used in each example file:
 ```
 @WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@
 ```
+
+The following table is the count of unknown relationship literals used in each example file:
+
+```
+@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@
+```

--- a/tests/casework.github.io/examples/asgard/Makefile
+++ b/tests/casework.github.io/examples/asgard/Makefile
@@ -52,9 +52,16 @@ all: \
 #   https://stackoverflow.com/a/6790967
 README.md: \
   .README.md.in \
+  wc_l_local_ontology_relationships.txt \
   wc_l_local_ontology_vocabulary.txt
 	rm -f _$@ __$@
 	cp .README.md.in __$@
+	sed \
+	  -e '/@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@/r wc_l_local_ontology_relationships.txt' \
+	  -e '/@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@/d' \
+	  __$@ \
+	  > _$@
+	cp _$@ __$@
 	sed \
 	  -e '/@WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@/r wc_l_local_ontology_vocabulary.txt' \
 	  -e '/@WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@/d' \
@@ -68,14 +75,32 @@ README.md: \
 # The .diff files should not be retained.  If any are found after calling 'make check', they illustrate a problem.
 check: \
   README.md.diff \
+  local_ontology_relationships-asgard.tsv.diff \
   local_ontology_vocabulary-asgard.txt.diff
 	@rm -f $^
 
 clean:
 	@rm -f \
 	  README.md \
+	  local_ontology_relationships-asgard.tsv \
 	  local_ontology_vocabulary-asgard.txt \
 	  wc_l_local_ontology_vocabulary.txt
+
+local_ontology_relationships-asgard.tsv: \
+  $(asgard_srcdir)/asgard.json \
+  $(top_srcdir)/src/data_relationship_literals_tsv.py \
+  $(top_srcdir)/tests/ontology_relationship_literals.tsv
+	source $(top_srcdir)/venv/bin/activate \
+	  && python3 $(top_srcdir)/src/data_relationship_literals_tsv.py \
+	    $< \
+	    > $@__
+	LC_ALL=C $(COMM) \
+	  -13 \
+	  $(top_srcdir)/tests/ontology_relationship_literals.tsv \
+	  <(LC_ALL=C $(SORT) $@__) \
+	  > $@_
+	rm $@__
+	mv $@_ $@
 
 local_ontology_vocabulary-asgard.txt: \
   $(asgard_srcdir)/asgard.json \
@@ -98,6 +123,14 @@ local_ontology_vocabulary-asgard.txt: \
 	    > $@_
 	rm $@__
 	mv $@_ $@
+
+wc_l_local_ontology_relationships.txt: \
+  local_ontology_relationships-asgard.tsv
+	$(WC) -l \
+	  local_ontology_relationships-asgard.tsv \
+	  | grep -v ' total' \
+	    > _$@
+	mv _$@ $@
 
 wc_l_local_ontology_vocabulary.txt: \
   local_ontology_vocabulary-asgard.txt

--- a/tests/casework.github.io/examples/asgard/README.md
+++ b/tests/casework.github.io/examples/asgard/README.md
@@ -7,3 +7,9 @@ The following table is the count of unknown terms yet used in each example file:
 ```
 8 local_ontology_vocabulary-asgard.txt
 ```
+
+The following table is the count of unknown relationship literals used in each example file:
+
+```
+1 local_ontology_relationships-asgard.tsv
+```

--- a/tests/casework.github.io/examples/asgard/local_ontology_relationships-asgard.tsv
+++ b/tests/casework.github.io/examples/asgard/local_ontology_relationships-asgard.tsv
@@ -1,0 +1,1 @@
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within

--- a/tests/casework.github.io/examples/owl_trafficking/.README.md.in
+++ b/tests/casework.github.io/examples/owl_trafficking/.README.md.in
@@ -7,3 +7,9 @@ The following table is the count of unknown terms yet used in each example file:
 ```
 @WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@
 ```
+
+The following table is the count of unknown relationship literals used in each example file:
+
+```
+@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@
+```

--- a/tests/casework.github.io/examples/owl_trafficking/Makefile
+++ b/tests/casework.github.io/examples/owl_trafficking/Makefile
@@ -52,9 +52,16 @@ all: \
 #   https://stackoverflow.com/a/6790967
 README.md: \
   .README.md.in \
+  wc_l_local_ontology_relationships.txt \
   wc_l_local_ontology_vocabulary.txt
 	rm -f _$@ __$@
 	cp .README.md.in __$@
+	sed \
+	  -e '/@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@/r wc_l_local_ontology_relationships.txt' \
+	  -e '/@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@/d' \
+	  __$@ \
+	  > _$@
+	cp _$@ __$@
 	sed \
 	  -e '/@WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@/r wc_l_local_ontology_vocabulary.txt' \
 	  -e '/@WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@/d' \
@@ -68,14 +75,32 @@ README.md: \
 # The .diff files should not be retained.  If any are found after calling 'make check', they illustrate a problem.
 check: \
   README.md.diff \
+  local_ontology_relationships-owl_trafficking.tsv.diff \
   local_ontology_vocabulary-owl_trafficking.txt.diff
 	@rm -f $^
 
 clean:
 	@rm -f \
 	  README.md \
+	  local_ontology_relationships-owl_trafficking.tsv \
 	  local_ontology_vocabulary-owl_trafficking.txt \
 	  wc_l_local_ontology_vocabulary.txt
+
+local_ontology_relationships-owl_trafficking.tsv: \
+  $(owl_trafficking_srcdir)/owl_trafficking.json \
+  $(top_srcdir)/src/data_relationship_literals_tsv.py \
+  $(top_srcdir)/tests/ontology_relationship_literals.tsv
+	source $(top_srcdir)/venv/bin/activate \
+	  && python3 $(top_srcdir)/src/data_relationship_literals_tsv.py \
+	    $< \
+	    > $@__
+	LC_ALL=C $(COMM) \
+	  -13 \
+	  $(top_srcdir)/tests/ontology_relationship_literals.tsv \
+	  <(LC_ALL=C $(SORT) $@__) \
+	  > $@_
+	rm $@__
+	mv $@_ $@
 
 local_ontology_vocabulary-owl_trafficking.txt: \
   $(owl_trafficking_srcdir)/owl_trafficking.json \
@@ -98,6 +123,14 @@ local_ontology_vocabulary-owl_trafficking.txt: \
 	    > $@_
 	rm $@__
 	mv $@_ $@
+
+wc_l_local_ontology_relationships.txt: \
+  local_ontology_relationships-owl_trafficking.tsv
+	$(WC) -l \
+	  local_ontology_relationships-owl_trafficking.tsv \
+	  | grep -v ' total' \
+	    > _$@
+	mv _$@ $@
 
 wc_l_local_ontology_vocabulary.txt: \
   local_ontology_vocabulary-owl_trafficking.txt

--- a/tests/casework.github.io/examples/owl_trafficking/README.md
+++ b/tests/casework.github.io/examples/owl_trafficking/README.md
@@ -7,3 +7,9 @@ The following table is the count of unknown terms yet used in each example file:
 ```
 33 local_ontology_vocabulary-owl_trafficking.txt
 ```
+
+The following table is the count of unknown relationship literals used in each example file:
+
+```
+2 local_ontology_relationships-owl_trafficking.tsv
+```

--- a/tests/casework.github.io/examples/owl_trafficking/local_ontology_relationships-owl_trafficking.tsv
+++ b/tests/casework.github.io/examples/owl_trafficking/local_ontology_relationships-owl_trafficking.tsv
@@ -1,0 +1,2 @@
+https://unifiedcyberontology.org/ontology/uco/vocabulary#ObservableObjectRelationshipVocab	Associated_Account
+https://unifiedcyberontology.org/ontology/uco/vocabulary#ObservableObjectRelationshipVocab	Has_Account

--- a/tests/casework.github.io/examples/urgent_evidence/.README.md.in
+++ b/tests/casework.github.io/examples/urgent_evidence/.README.md.in
@@ -7,3 +7,9 @@ The following table is the count of unknown terms yet used in each example file:
 ```
 @WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@
 ```
+
+The following table is the count of unknown relationship literals used in each example file:
+
+```
+@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@
+```

--- a/tests/casework.github.io/examples/urgent_evidence/Makefile
+++ b/tests/casework.github.io/examples/urgent_evidence/Makefile
@@ -52,9 +52,16 @@ all: \
 #   https://stackoverflow.com/a/6790967
 README.md: \
   .README.md.in \
+  wc_l_local_ontology_relationships.txt \
   wc_l_local_ontology_vocabulary.txt
 	rm -f _$@ __$@
 	cp .README.md.in __$@
+	sed \
+	  -e '/@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@/r wc_l_local_ontology_relationships.txt' \
+	  -e '/@WC_L_LOCAL_ONTOLOGY_RELATIONSHIPS_TXT@/d' \
+	  __$@ \
+	  > _$@
+	cp _$@ __$@
 	sed \
 	  -e '/@WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@/r wc_l_local_ontology_vocabulary.txt' \
 	  -e '/@WC_L_LOCAL_ONTOLOGY_VOCABULARY_TXT@/d' \
@@ -68,14 +75,32 @@ README.md: \
 # The .diff files should not be retained.  If any are found after calling 'make check', they illustrate a problem.
 check: \
   README.md.diff \
+  local_ontology_relationships-urgent_evidence.tsv.diff \
   local_ontology_vocabulary-urgent_evidence.txt.diff
 	@rm -f $^
 
 clean:
 	@rm -f \
 	  README.md \
+	  local_ontology_relationships-urgent_evidence.tsv \
 	  local_ontology_vocabulary-urgent_evidence.txt \
 	  wc_l_local_ontology_vocabulary.txt
+
+local_ontology_relationships-urgent_evidence.tsv: \
+  $(urgent_evidence_srcdir)/urgent_evidence.json \
+  $(top_srcdir)/src/data_relationship_literals_tsv.py \
+  $(top_srcdir)/tests/ontology_relationship_literals.tsv
+	source $(top_srcdir)/venv/bin/activate \
+	  && python3 $(top_srcdir)/src/data_relationship_literals_tsv.py \
+	    $< \
+	    > $@__
+	LC_ALL=C $(COMM) \
+	  -13 \
+	  $(top_srcdir)/tests/ontology_relationship_literals.tsv \
+	  <(LC_ALL=C $(SORT) $@__) \
+	  > $@_
+	rm $@__
+	mv $@_ $@
 
 local_ontology_vocabulary-urgent_evidence.txt: \
   $(urgent_evidence_srcdir)/urgent_evidence.json \
@@ -97,6 +122,14 @@ local_ontology_vocabulary-urgent_evidence.txt: \
 	  > $@_
 	rm $@__
 	mv $@_ $@
+
+wc_l_local_ontology_relationships.txt: \
+  local_ontology_relationships-urgent_evidence.tsv
+	$(WC) -l \
+	  local_ontology_relationships-urgent_evidence.tsv \
+	  | grep -v ' total' \
+	    > _$@
+	mv _$@ $@
 
 wc_l_local_ontology_vocabulary.txt: \
   local_ontology_vocabulary-urgent_evidence.txt

--- a/tests/casework.github.io/examples/urgent_evidence/README.md
+++ b/tests/casework.github.io/examples/urgent_evidence/README.md
@@ -7,3 +7,9 @@ The following table is the count of unknown terms yet used in each example file:
 ```
 3 local_ontology_vocabulary-urgent_evidence.txt
 ```
+
+The following table is the count of unknown relationship literals used in each example file:
+
+```
+1 local_ontology_relationships-urgent_evidence.tsv
+```

--- a/tests/casework.github.io/examples/urgent_evidence/local_ontology_relationships-urgent_evidence.tsv
+++ b/tests/casework.github.io/examples/urgent_evidence/local_ontology_relationships-urgent_evidence.tsv
@@ -1,0 +1,1 @@
+https://unifiedcyberontology.org/ontology/uco/observable#ObservableObjectRelationshipEnum	Contained_Within


### PR DESCRIPTION
Ontology-vocabulary tests to date have not included review of
vocabularies used in UCO.  This patch adds reporting of current
vocabulary literals used in kindOfRelationship throughout the website
and CASE-Examples examples, in support of UCO CP-49 and CP-47.

References:
* [UCO OC-56] (CP-49) UCO needs to document the core:Relationship object
  and why it is used instead of RDF predicates
* [UCO OC-121] (CP-47) CASE has always used Has_Role relationship in
  examples, but UCO does not have it

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>