### PR TITLE
Use Python venv to build virtual environment for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Python virtualenv for Github runner
-      run: |
-        python -m pip install --upgrade pip
-        pip install virtualenv
     - name: Start from clean state
       run: make clean
     - name: Normalize example files

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,6 @@ SHELL = /bin/bash
 
 PYTHON3 ?= $(shell which python3.8 2>/dev/null || which python3.7 2>/dev/null || which python3.6 2>/dev/null || which python3)
 
-VIRTUALENV ?= $(shell which virtualenv-3.8 2>/dev/null || which virtualenv-3.7 2>/dev/null || which virtualenv-3.6 2>/dev/null || which virtualenv)
-
 all: \
   .git_submodule_init.done.log \
   .lib.done.log \
@@ -88,12 +86,8 @@ all: \
 
 .venv.done.log: \
   deps/requirements.txt
-	@test ! -z "$(VIRTUALENV)" \
-	  || (echo "ERROR:Makefile:virtualenv not found." >&2 ; exit 2)
 	rm -rf venv
-	$(VIRTUALENV) \
-	  --python=$(PYTHON3) \
-	  --system-site-packages \
+	$(PYTHON3) -m venv \
 	  venv
 	source venv/bin/activate \
 	  && pip install \


### PR DESCRIPTION
References:
* [AC-195] Use Python venv instead of virtualenv to build virtual
  environments for CI

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>