### PR TITLE
Use Java 8 for rdf-toolkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: '8'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
References:
* [UCO OC-164] (CP-71) Ontology syntax-check CI does not run with
  Java 11

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>