### PR TITLE
Remove archived package rdflib-jsonld from build

### DIFF
--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -1,4 +1,3 @@
 pytest
-rdflib
-rdflib-jsonld
+rdflib >= 6.0.0
 requests


### PR DESCRIPTION
References:
* Adjust Python packages importing rdflib-jsonld to import
  rdflib >= 6.0.0

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>